### PR TITLE
Fixes iteritems() deprecation

### DIFF
--- a/kreep/beam.py
+++ b/kreep/beam.py
@@ -22,7 +22,7 @@ def predict_phrases(word_probs, lm, k, alpha):
 
         new_beam = []
         for l,l_score in beam:
-            for token, km_prob in word_probs_i.iteritems():
+            for token, km_prob in word_probs_i.items():
                 lm_prob = lm(token, history=l)
                 score = l_score + km_prob + lm_prob * alpha
                 new_beam.append((l + (token,), score))


### PR DESCRIPTION
I found that `iteritems()` has been [deprecated](https://github.com/pandas-dev/pandas/pull/45321) in Pandas, updated it to use `items()`.